### PR TITLE
Code for Issue #3 - Add dmore program options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# perfmon
+# node-perfmon-dh
 
 Streaming [Performance Monitor](http://technet.microsoft.com/en-us/library/cc749249.aspx) metrics for [Node](http://nodejs.org) on Windows.
 
-[node-perfmon](http://markitondemand.github.com/node-perfmon) is a thin wrapper around [typeperf](http://technet.microsoft.com/en-us/library/bb490960.aspx), and provides a [ReadableStream](http://nodejs.org/docs/latest/api/streams.html#readable_Stream) interface to the typeperf output.  Metrics are streamed once per second.  `perfmon` wraps up the typeperf executable as a child_process. It ensures that no more than one process will be spawned for each host machine streaming metrics.
+[node-perfmon-dh](https://github.com/davehibshman/node-perfmon-dh) is a fork of [node-perfmon](http://markitondemand.github.com/node-perfmon).  I forked that repo and submitted pull requests for functionality I previously requested be added.  It doesn't look like the owner is maintaining it anymore, so I published my fork.  If the original is maintained, then I will remove this one.  Most of this README is a copy of the original with a few changes supporting the reasons I forked it.  
+
+[node-perfmon](http://markitondemand.github.com/node-perfmon) is a thin wrapper around MS Windows [typeperf](http://technet.microsoft.com/en-us/library/bb490960.aspx) command that provides a [ReadableStream](http://nodejs.org/docs/latest/api/streams.html#readable_Stream) interface to the typeperf command output.  `perfmon` wraps up the typeperf executable as a child_process. It ensures that no more than one process will be spawned for each host machine streaming metrics.
 
 ### Dependenices
 
@@ -27,6 +29,17 @@ perfmon('\\processor(_total)\\% processor time', function(err, data) {
 	console.log(data);
 });
 ```
+
+Perfmon can also be called with an options object instead of the counters and hosts args.  This options object supports the following properties:
+```javascript
+{
+  counters:[],             // array of counters as string
+  hosts:[],                // array of hosts as strings
+  sampleInterval: Number,  // Number indicating how many seconds between metric samples (-si), default is 1
+  sampleCount: Number      // Number indicating how many sample to run (-sc)
+}
+```
+
 
 The `data` object logged to the console:
 

--- a/examples/options.js
+++ b/examples/options.js
@@ -1,0 +1,22 @@
+var perfmon = require('../perfmon');
+
+var counters = [
+	'\\processor(_total)\\% processor time',
+	'\\Memory\\Available bytes'
+];
+
+perfmon({counters:counters, sampleInterval:5, sampleCount:5}, function(err, data) {
+	var date = new Date(data.time);
+	// display in format HH:MM:SS	
+	data.time = twoDigits(date.getHours()) 
+      + ':' + twoDigits(date.getMinutes()) 
+      + ':' + twoDigits(date.getSeconds());
+	console.log(data);
+});
+
+function twoDigits(value) {
+   if(value < 10) {
+    return '0' + value;
+   }
+   return value;
+}

--- a/lib/TypePerf.js
+++ b/lib/TypePerf.js
@@ -12,6 +12,9 @@ function TypePerf(host, counters) {
 
 	this._counters = [];
 	this.readable = true;
+	
+	this.sampleInterval = null;
+    this.sampleCount = null;
 
 	this.counters(counters);
 }
@@ -92,6 +95,7 @@ TypePerf.prototype.spawn = function() {
 	var self = this;
 	var stdoutBuffer = '';
 	var counters = this._counters;
+	var progOpts = this._counters.concat(['-s', this.host]);
 
 	// no need to spawn multiple, counters always append,
 	// so last spawner is most accurate
@@ -101,11 +105,16 @@ TypePerf.prototype.spawn = function() {
 		});
 		self.spawning = [];
 	}
+	
+	if (!isNaN(parseInt(this.sampleInterval, 10))) {
+        progOpts = progOpts.concat(['-si', this.sampleInterval]);
+    }
 
-	cp = spawn('TypePerf', this._counters.concat([
-		'-s',
-		this.host
-	]));
+    if (!isNaN(parseInt(this.sampleCount, 10))) {
+        progOpts = progOpts.concat(['-sc', this.sampleCount]);
+    }
+
+    cp = spawn('TypePerf', progOpts);	
 
 	self.spawning.push(cp);
 	self.cp.push(cp);

--- a/package.json
+++ b/package.json
@@ -1,19 +1,18 @@
 {
-	"name": "perfmon",
-	"version": "0.2.1",
-	"author": "Ben Taber (ben.taber@markit.com)",
+	"name": "node-perfmon-dh",
+	"version": "0.3.1",
+	"author": "David Hibshman (davehibshman@gmail.com)",
 
 	"description": "Windows perfmon metrics stream",
 	"keywords": "perfmon logman typeperf win32 windows metrics stream monitor performance",
 
-	"homepage": "https://github.com/markitondemand/node-perfmon",
-	"bugs": "https://github.com/markitondemand/node-perfmon/issues",
+	"homepage": "https://github.com/davehibshman/node-perfmon-dh",
 
 	"main": "./perfmon.js",
 
 	"repository": { 
 		"type" : "git",
-		"url" : "https://github.com/markitondemand/node-perfmon.git"
+		"url" : "https://github.com/davehibshman/node-perfmon-dh.git"
 	},
 
 	"os": ["win32"],

--- a/perfmon.js
+++ b/perfmon.js
@@ -32,6 +32,15 @@ function init(host, options, pstream) {
 	}
 
 	typePerf = hosts[host];
+	
+	if (options.sampleInterval) {
+        typePerf.sampleInterval = options.sampleInterval;
+    }
+
+    if (options.sampleCount) {
+        typePerf.sampleCount = options.sampleCount;
+    }
+	
 	pstream.attach(typePerf);
 
 	// this is wrong. if the current typeperf ALREADY contains the new


### PR DESCRIPTION
Extended object that perform() function can be passed to accept sampleInterval and sampleCount properties.  Changed typePerf.js to support and detect the same properties and if found add -si and -sc program option for typeperf command.  Seemed easiest to add thi without changing code significantly.
